### PR TITLE
Missing /sys/kernel/debug/ec/ec0/io FIX

### DIFF
--- a/at_startup.sh
+++ b/at_startup.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
 cd $(pwd)
+sudo modprobe ec_sys write_support=1
 nohup ./install_deps.sh >/dev/null 2>&1
 nohup python3 indicator.py >/dev/null 2>&1 & exit


### PR DESCRIPTION
Fixed an issue I had where `/sys/kernel/debug/ec/ec0/io` was not accessible.